### PR TITLE
Prevent rebuild on changed Widget size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+FIX
+- Removed `LayoutBuilder` from root of `InfiniteScrollTabView`. This change prevents some performance issue.
+
 ## 1.0.1
 FIX
 - Added `indicatorHeight` property to `InfintieScrollTabView`. It will override indicator height if specified non-null value.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.0.2"
   lints:
     dependency: transitive
     description:

--- a/lib/src/infinite_scroll_tab_view.dart
+++ b/lib/src/infinite_scroll_tab_view.dart
@@ -32,6 +32,7 @@ class InfiniteScrollTabView extends StatelessWidget {
     this.indicatorHeight,
     this.tabHeight = 44.0,
     this.tabPadding = 12.0,
+    this.size,
   }) : super(key: key);
 
   /// A length of tabs and pages.
@@ -104,31 +105,38 @@ class InfiniteScrollTabView extends StatelessWidget {
   /// the tabs will have padding as `EdgeInsets.symmetric(horizontal: 12.0)`.
   final double tabPadding;
 
+  /// The size constraint of this widget.
+  ///
+  /// If this is null, then `MediaQuery.of(context).size` is used as default.
+  /// This value should specify only in some rare case, testing or something
+  /// like that.
+  /// Internally this is only used for get page width, but this value determines
+  /// entire widget's width.
+  final Size? size;
+
   @override
   Widget build(BuildContext context) {
     if (indicatorHeight != null) {
       assert(indicatorHeight! >= 1.0);
     }
 
-    return LayoutBuilder(
-      builder: (context, constraint) => InnerInfiniteScrollTabView(
-        size: constraint.biggest,
-        contentLength: contentLength,
-        tabBuilder: tabBuilder,
-        pageBuilder: pageBuilder,
-        onTabTap: onTabTap,
-        separator: separator,
-        textScaleFactor: MediaQuery.of(context).textScaleFactor,
-        defaultTextStyle: DefaultTextStyle.of(context).style,
-        textDirection: Directionality.of(context),
-        backgroundColor: backgroundColor,
-        onPageChanged: onPageChanged,
-        indicatorColor: indicatorColor,
-        indicatorHeight: indicatorHeight,
-        defaultLocale: Localizations.localeOf(context),
-        tabHeight: tabHeight,
-        tabPadding: tabPadding,
-      ),
+    return InnerInfiniteScrollTabView(
+      size: MediaQuery.of(context).size,
+      contentLength: contentLength,
+      tabBuilder: tabBuilder,
+      pageBuilder: pageBuilder,
+      onTabTap: onTabTap,
+      separator: separator,
+      textScaleFactor: MediaQuery.of(context).textScaleFactor,
+      defaultTextStyle: DefaultTextStyle.of(context).style,
+      textDirection: Directionality.of(context),
+      backgroundColor: backgroundColor,
+      onPageChanged: onPageChanged,
+      indicatorColor: indicatorColor,
+      indicatorHeight: indicatorHeight,
+      defaultLocale: Localizations.localeOf(context),
+      tabHeight: tabHeight,
+      tabPadding: tabPadding,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: infinite_scroll_tab_view
 description: A Flutter package for tab view component that can scroll infinitely.
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/cb-cloud/flutter_infinite_scroll_tab_view
 
 environment:


### PR DESCRIPTION
Just removed `LayoutBuilder`, because it causes performance issue on changed Widget bound from external factor.